### PR TITLE
binary stl files starting with "solid" in its header 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ hs_err_pid*
 /dist/
 /nbproject/private/
 /build/
+/bin/

--- a/src/hall/collin/christopher/stl4j/STLParser.java
+++ b/src/hall/collin/christopher/stl4j/STLParser.java
@@ -80,7 +80,7 @@ public class STLParser {
 		if(token.equals("solid")) { //start with "solid"
 			if(inl>-1) { //found new line for next line			
 				sb = new StringBuffer();
-				inl = readline(buf, sb, inl+1); //read next line, update inl
+				inl = readline(buf, sb, inl+1); //read next line
 				line = sb.toString();
 				st = new StringTokenizer(line);
 				token = st.nextToken();


### PR DESCRIPTION
some binary stl files starts with "solid" in its header that confuses a parser which depends on "solid" to tell if it is ascii or binary